### PR TITLE
Recategorize expenses in mass

### DIFF
--- a/src/main/java/victorbwd/api_gerenciamento_despesas/controllers/ExpensesController.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/controllers/ExpensesController.java
@@ -1,5 +1,6 @@
 package victorbwd.api_gerenciamento_despesas.controllers;
 
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +28,7 @@ public class ExpensesController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<ExpenseResponseDTO> createExpense(@RequestBody CreateExpenseDTO dto, Authentication auth) {
+    public ResponseEntity<ExpenseResponseDTO> createExpense(@Valid @RequestBody CreateExpenseDTO dto, Authentication auth) {
         UUID userId = authService.extractUserIdFromAuth(auth);
         Expenses expenses = expensesService.create(dto, userId);
 

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/controllers/ExpensesController.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/controllers/ExpensesController.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/expenses")
@@ -124,5 +125,31 @@ public class ExpensesController {
         expensesService.delete(id, user.getId());
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/recategorize")
+    public ResponseEntity<List<ExpenseResponseDTO>> recategorize(@RequestBody @Valid RecategorizeRequestDTO dto, Authentication auth) {
+        UUID userId = authService.extractUserIdFromAuth(auth);
+        if (userId == null) {
+            throw new UserNotFoundException("User not found");
+        }
+        User user = authService.getUserById(userId);
+
+        List<Expenses> updatedExpenses = expensesService.recategorizeExpenses(dto, user.getId());
+
+        List<ExpenseResponseDTO> response = updatedExpenses.stream().map(this::convertToDto).collect(Collectors.toList());
+
+        return ResponseEntity.ok(response);
+    }
+
+    private ExpenseResponseDTO convertToDto(Expenses expense) {
+        return new ExpenseResponseDTO(
+                expense.getId(),
+                expense.getDescription(),
+                expense.getAmount(),
+                expense.getCategory().getName(),
+                expense.getDate(),
+                expense.getUser().getName()
+        );
     }
 }

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/domain/expenses/Expenses.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/domain/expenses/Expenses.java
@@ -45,4 +45,7 @@ public class Expenses {
 
     @Column(nullable = false)
     private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @Version
+    private Long version;
 }

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/dto/CreateExpenseDTO.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/dto/CreateExpenseDTO.java
@@ -14,7 +14,6 @@ public record CreateExpenseDTO(
         @NotNull(message = "Value cannot be null")
         Double value,
 
-        @NotBlank(message = "Category cannot be blank")
         @Size(min = 2, max = 50, message = "Category must be between 2 and 50 characters")
         String category,
 

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/dto/CreateExpenseDTO.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/dto/CreateExpenseDTO.java
@@ -1,13 +1,25 @@
 package victorbwd.api_gerenciamento_despesas.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDate;
 import java.util.UUID;
 
 public record CreateExpenseDTO(
+        @Size(max = 100, message = "Description must be up to 100 characters")
         String description,
+
+        @NotNull(message = "Value cannot be null")
         Double value,
+
+        @NotBlank(message = "Category cannot be blank")
+        @Size(min = 2, max = 50, message = "Category must be between 2 and 50 characters")
         String category,
+
         UUID userId,
+
         LocalDate date
 ) {
 

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/dto/RecategorizeRequestDTO.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/dto/RecategorizeRequestDTO.java
@@ -1,0 +1,13 @@
+package victorbwd.api_gerenciamento_despesas.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record RecategorizeRequestDTO(
+        @NotEmpty
+        List<Long> expenseIds,
+
+        Long categoryId
+) {
+}

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/dto/RecategorizeRequestDTO.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/dto/RecategorizeRequestDTO.java
@@ -1,11 +1,13 @@
 package victorbwd.api_gerenciamento_despesas.dto;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public record RecategorizeRequestDTO(
         @NotEmpty
+        @Size(max = 50)
         List<Long> expenseIds,
 
         Long categoryId

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/exceptions/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package victorbwd.api_gerenciamento_despesas.exceptions;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,6 +12,19 @@ import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(
+            MethodArgumentNotValidException ex) {
+
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Map<String, String> handleIllegalArgumentException(IllegalArgumentException ex) {

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/repositories/CategoryRepository.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/repositories/CategoryRepository.java
@@ -17,4 +17,7 @@ public interface CategoryRepository extends JpaRepository<Category,Integer> {
     boolean existsByNameAndUserIdOrDefault(@Param("name") String name, @Param("userId") UUID userId);
 
     Optional<Category> findByName(String name);
+
+    @Query("SELECT c FROM Category c WHERE c.id = :categoryId AND (c.user.id = :userId OR c.user IS NULL)")
+    Optional<Category> findByIdForUserOrDefault(@Param("categoryId") Integer categoryId, @Param("userId") UUID userId);
 }

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/services/ExpensesService.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/services/ExpensesService.java
@@ -155,13 +155,7 @@ public class ExpensesService {
     }
 
     public List<Expenses> recategorizeExpenses(RecategorizeRequestDTO dto, UUID userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("User not found"));
         List<Expenses> expenses = expensesRepository.findAllById(dto.expenseIds());
-
-        System.out.println("--- INICIANDO DEBUG ---");
-        System.out.println("Tentando encontrar Category ID: " + dto.categoryId());
-        System.out.println("Para o User ID: " + userId);
-        System.out.println("-----------------------");
 
         boolean hasInvalidExpenses = expenses.size() != dto.expenseIds().size() ||
                 !expenses.stream().allMatch(exp -> exp.getUser().getId().equals(userId));

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/services/ExpensesService.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/services/ExpensesService.java
@@ -119,7 +119,7 @@ public class ExpensesService {
 
         if (dto.category() != null && !dto.category().isBlank()) {
             Category category = categoryRepository.findByName(dto.category())
-                    .orElseThrow(() -> new CategoryNotFoundException("Category '" + dto.category() + "' not found"));
+                    .orElseThrow(() -> new CategoryNotFoundException("Category not found"));
             expense.setCategory(category);
         }
         else {

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/services/ExpensesService.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/services/ExpensesService.java
@@ -117,6 +117,7 @@ public class ExpensesService {
         return convertToResponseDTO(expense);
     }
 
+    @Transactional
     public ExpenseResponseDTO update(Long id, UpdateExpenseDTO dto, UUID userId) {
         Expenses expense = expensesRepository.findByIdAndUserId(id, userId).orElseThrow(() -> new ExpenseNotFoundException("Expense not found"));
 

--- a/src/main/java/victorbwd/api_gerenciamento_despesas/services/ExpensesService.java
+++ b/src/main/java/victorbwd/api_gerenciamento_despesas/services/ExpensesService.java
@@ -21,6 +21,7 @@ import victorbwd.api_gerenciamento_despesas.repositories.UserRepository;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.List;
 
@@ -61,7 +62,16 @@ public class ExpensesService {
                     .orElseThrow(() -> new CategoryNotFoundException("Category not found"));
             expenses.setCategory(category);
         } else {
-            categorizationEngineService.findCategoryForRule(expenses).ifPresent(expenses::setCategory);
+
+            Optional<Category> foundCategory = categorizationEngineService.findCategoryForRule(expenses);
+
+            if (foundCategory.isPresent()) {
+                expenses.setCategory(foundCategory.get());
+            } else {
+                Category defaultCategory = categoryRepository.findByName("Sem Categoria")
+                        .orElseThrow(() -> new RuntimeException("Categoria padrão 'Sem Categoria' não encontrada no banco de dados."));
+                expenses.setCategory(defaultCategory);
+            }
         }
 
         return expensesRepository.save(expenses);

--- a/src/main/resources/db/migration/V20250921193400__create_version_expenses_table.sql
+++ b/src/main/resources/db/migration/V20250921193400__create_version_expenses_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE expenses ADD COLUMN version BIGINT;

--- a/src/main/resources/db/migration/V20250921194100__create_default_category.sql
+++ b/src/main/resources/db/migration/V20250921194100__create_default_category.sql
@@ -1,0 +1,1 @@
+INSERT INTO categories (name, color, is_default, user_id) VALUES ('Sem Categoria', '#FFFFFF', true, null);

--- a/src/main/resources/db/migration/V20250921204000__update_version_column.sql
+++ b/src/main/resources/db/migration/V20250921204000__update_version_column.sql
@@ -1,0 +1,1 @@
+UPDATE expenses SET version = 0 WHERE version IS NULL;


### PR DESCRIPTION
- Endpoint to recategorize one, two, or more expenses...
- Version in expense domain to avoid race condition
- Fix bug where the api don't let you register a expense without category
- Added category "Sem Categoria" when user doesn't have a rule
- Fix bug when PUT expense with null version column